### PR TITLE
Fix: Correct install.py method name typo (download_model → download_default_model)

### DIFF
--- a/install.py
+++ b/install.py
@@ -333,7 +333,7 @@ python main.py
                     # Ask about model download
                     download_model = input("\nDownload default model (medium, ~769MB)? (y/N): ").lower().startswith('y')
                     if download_model:
-                        self.download_model()
+                        self.download_default_model()
 
             print("\n" + "="*50)
             print("INSTALLATION COMPLETED!")


### PR DESCRIPTION
## Bug Fix - Critical Installation Issue

...oad_default_model()

- Fixed AttributeError during installation when downloading default model
- The method was incorrectly called as self.download_model() instead of self.download_default_model()
- This bug prevented users from completing the installation when choosing to download models
- Tested and verified the fix works correctly

### Impact
- Resolves installation blocker for new users
- One-line fix, safe to merge immediately